### PR TITLE
[deploy/env] add ability to specify multiple charts files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Additional flags:
 * Use the `-p` (parallel) flag to specify parallelism of chart deployments.
 * Use the `-f` flag to specify different values files to use during deployment.
 * Use the `-s` flag to set additional parameters.
+* Use the `-c` flag multiple times to specify multiple charts files to be merged from left to right (currently only merges version fields)
 
 #### Get the "stable" environment and deploy the same configuration to a new environment, with override(s) and environment refresh
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -92,7 +92,7 @@ Aliases:
 
 Flags:
       --annotations strings                  additional environment (namespace) annotations (can specify multiple): annotation=value
-  -c, --charts-file string                   path to file with list of Helm charts to install. Overrides $ORCA_CHARTS_FILE
+      --charts-file strings                  path to file with list of Helm charts to install (can specify multiple)
   -x, --deploy-only-override-if-env-exists   if environment exists - deploy only override(s) (avoid environment update). Overrides $ORCA_DEPLOY_ONLY_OVERRIDE_IF_ENV_EXISTS
       --helm-tls-store string                path to TLS certs and keys. Overrides $HELM_TLS_STORE
       --inject                               enable injection during helm upgrade. Overrides $ORCA_INJECT (requires helm inject plugin: https://github.com/maorfr/helm-inject)

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -92,7 +92,7 @@ Aliases:
 
 Flags:
       --annotations strings                  additional environment (namespace) annotations (can specify multiple): annotation=value
-      --charts-file strings                  path to file with list of Helm charts to install (can specify multiple)
+  -c, --charts-file strings                  path to file with list of Helm charts to install (can specify multiple)
   -x, --deploy-only-override-if-env-exists   if environment exists - deploy only override(s) (avoid environment update). Overrides $ORCA_DEPLOY_ONLY_OVERRIDE_IF_ENV_EXISTS
       --helm-tls-store string                path to TLS certs and keys. Overrides $HELM_TLS_STORE
       --inject                               enable injection during helm upgrade. Overrides $ORCA_INJECT (requires helm inject plugin: https://github.com/maorfr/helm-inject)

--- a/pkg/orca/env.go
+++ b/pkg/orca/env.go
@@ -288,7 +288,7 @@ func NewDeployEnvCmd(out io.Writer) *cobra.Command {
 
 	f := cmd.Flags()
 
-	f.StringSliceVar(&e.chartsFile, "charts-file", []string{}, "path to file with list of Helm charts to install (can specify multiple)")
+	f.StringSliceVarP(&e.chartsFile, "charts-file", "c", []string{}, "path to file with list of Helm charts to install (can specify multiple)")
 	f.StringSliceVar(&e.override, "override", []string{}, "chart to override with different version (can specify multiple): chart=version")
 	f.StringVarP(&e.name, "name", "n", os.Getenv("ORCA_NAME"), "name of environment (namespace) to deploy to. Overrides $ORCA_NAME")
 	f.StringVar(&e.repo, "repo", os.Getenv("ORCA_REPO"), "chart repository (name=url). Overrides $ORCA_REPO")

--- a/pkg/orca/env.go
+++ b/pkg/orca/env.go
@@ -26,7 +26,7 @@ const (
 )
 
 type envCmd struct {
-	chartsFile                    string
+	chartsFile                    []string
 	name                          string
 	override                      []string
 	packedValues                  []string
@@ -123,14 +123,14 @@ func NewDeployEnvCmd(out io.Writer) *cobra.Command {
 				}
 			}
 			if len(e.override) == 0 {
-				if e.chartsFile == "" {
+				if len(e.chartsFile) == 0 {
 					return errors.New("either charts-file or override has to be defined")
 				}
 				if e.deployOnlyOverrideIfEnvExists {
 					return errors.New("override has to be defined when using using deploy-only-override-if-env-exists")
 				}
 			}
-			if e.chartsFile != "" && utils.CheckCircularDependencies(utils.InitReleasesFromChartsFile(e.chartsFile, e.name)) {
+			if len(e.chartsFile) != 0 && utils.CheckCircularDependencies(utils.InitReleasesFromChartsFiles(e.chartsFile, e.name)) {
 				return errors.New("Circular dependency found")
 			}
 			return nil
@@ -182,8 +182,8 @@ func NewDeployEnvCmd(out io.Writer) *cobra.Command {
 			if nsPreExists && e.deployOnlyOverrideIfEnvExists {
 				desiredReleases = utils.InitReleases(e.name, e.override)
 			} else {
-				if e.chartsFile != "" {
-					desiredReleases = utils.InitReleasesFromChartsFile(e.chartsFile, e.name)
+				if len(e.chartsFile) != 0 {
+					desiredReleases = utils.InitReleasesFromChartsFiles(e.chartsFile, e.name)
 				}
 				desiredReleases = utils.OverrideReleases(desiredReleases, e.override, e.name)
 			}
@@ -288,7 +288,7 @@ func NewDeployEnvCmd(out io.Writer) *cobra.Command {
 
 	f := cmd.Flags()
 
-	f.StringVarP(&e.chartsFile, "charts-file", "c", os.Getenv("ORCA_CHARTS_FILE"), "path to file with list of Helm charts to install. Overrides $ORCA_CHARTS_FILE")
+	f.StringSliceVar(&e.chartsFile, "charts-file", []string{}, "path to file with list of Helm charts to install (can specify multiple)")
 	f.StringSliceVar(&e.override, "override", []string{}, "chart to override with different version (can specify multiple): chart=version")
 	f.StringVarP(&e.name, "name", "n", os.Getenv("ORCA_NAME"), "name of environment (namespace) to deploy to. Overrides $ORCA_NAME")
 	f.StringVar(&e.repo, "repo", os.Getenv("ORCA_REPO"), "chart repository (name=url). Overrides $ORCA_REPO")

--- a/test/chart_test.go
+++ b/test/chart_test.go
@@ -23,6 +23,48 @@ func TestGetReleasesDelta(t *testing.T) {
 		t.Errorf("Expected: true, Actual: false")
 	}
 }
+func TestChartsMultipleYamlToReleases_SingleOverride(t *testing.T) {
+	files := []string{"data/charts_base.yaml", "data/charts_override.1.yaml"}
+	rel0 := utils.ReleaseSpec{ChartName: "cassandra", ChartVersion: "0.4.0", ReleaseName: "test-cassandra"}
+	rel1 := utils.ReleaseSpec{ChartName: "mariadb", ChartVersion: "0.5.4", ReleaseName: "test-mariadb"}
+	rel2 := utils.ReleaseSpec{ChartName: "kaa", ChartVersion: "0.1.7", ReleaseName: "test-kaa"}
+
+	releases := utils.InitReleasesFromChartsFiles(files, "test")
+
+	if len(releases) != 3 {
+		t.Errorf("Expected: 3, Actual: " + (string)(len(releases)))
+	}
+	if !releases[0].Equals(rel0) {
+		t.Errorf("Expected: true, Actual: false")
+	}
+	if !releases[1].Equals(rel1) {
+		t.Errorf("Expected: true, Actual: false")
+	}
+	if !releases[2].Equals(rel2) {
+		t.Errorf("Expected: true, Actual: false")
+	}
+}
+func TestChartsMultipleYamlToReleases_MultipleOverride(t *testing.T) {
+	files := []string{"data/charts_base.yaml", "data/charts_override.1.yaml", "data/charts_override.2.yaml"}
+	rel0 := utils.ReleaseSpec{ChartName: "cassandra", ChartVersion: "0.4.0", ReleaseName: "test-cassandra"}
+	rel1 := utils.ReleaseSpec{ChartName: "mariadb", ChartVersion: "0.5.4", ReleaseName: "test-mariadb"}
+	rel2 := utils.ReleaseSpec{ChartName: "kaa", ChartVersion: "0.1.8", ReleaseName: "test-kaa"}
+
+	releases := utils.InitReleasesFromChartsFiles(files, "test")
+
+	if len(releases) != 3 {
+		t.Errorf("Expected: 3, Actual: " + (string)(len(releases)))
+	}
+	if !releases[0].Equals(rel0) {
+		t.Errorf("Expected: true, Actual: false")
+	}
+	if !releases[1].Equals(rel1) {
+		t.Errorf("Expected: true, Actual: false")
+	}
+	if !releases[2].Equals(rel2) {
+		t.Errorf("Expected: true, Actual: false")
+	}
+}
 func TestChartsYamlToReleases(t *testing.T) {
 	file := "data/charts.yaml"
 	rel0 := utils.ReleaseSpec{ChartName: "cassandra", ChartVersion: "0.4.0", ReleaseName: "test-cassandra"}

--- a/test/data/charts_base.yaml
+++ b/test/data/charts_base.yaml
@@ -1,0 +1,10 @@
+charts:
+- name: cassandra
+  version: nil
+- name: mariadb
+  version: nil
+- name: kaa
+  version: nil
+  depends_on:
+  - cassandra
+  - mariadb

--- a/test/data/charts_override.1.yaml
+++ b/test/data/charts_override.1.yaml
@@ -1,0 +1,8 @@
+charts:
+- name: cassandra
+  version: 0.4.0
+- name: mariadb
+  version: 0.5.4
+- name: kaa
+  version: 0.1.7
+

--- a/test/data/charts_override.2.yaml
+++ b/test/data/charts_override.2.yaml
@@ -1,0 +1,4 @@
+charts:
+- name: kaa
+  version: 0.1.8
+


### PR DESCRIPTION
This PR closes issue #15 

It does not fix the coverage file. This will be done in a separate PR.