### PR TITLE
Correct docs for lock/unlock/validate flags

### DIFF
--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -155,7 +155,7 @@ Usage:
 
 Flags:
       --kube-context string   name of the kubeconfig context to use. Overrides $ORCA_KUBE_CONTEXT
-  -n, --name string           name of environment (namespace) to delete. Overrides $ORCA_NAME
+  -n, --name string           name of environment (namespace) to lock. Overrides $ORCA_NAME
 ```
 
 ### Unlock env
@@ -167,7 +167,7 @@ Usage:
 
 Flags:
       --kube-context string   name of the kubeconfig context to use. Overrides $ORCA_KUBE_CONTEXT
-  -n, --name string           name of environment (namespace) to delete. Overrides $ORCA_NAME
+  -n, --name string           name of environment (namespace) to unlock. Overrides $ORCA_NAME
 ```
 
 ### Validate env
@@ -179,7 +179,7 @@ Usage:
 
 Flags:
       --kube-context string   name of the kubeconfig context to use. Overrides $ORCA_KUBE_CONTEXT
-  -n, --name string           name of environment (namespace) to delete. Overrides $ORCA_NAME
+  -n, --name string           name of environment (namespace) to validate. Overrides $ORCA_NAME
 ```
 
 ### Create resource

--- a/pkg/orca/env.go
+++ b/pkg/orca/env.go
@@ -422,7 +422,7 @@ func NewLockEnvCmd(out io.Writer) *cobra.Command {
 
 	f := cmd.Flags()
 
-	f.StringVarP(&e.name, "name", "n", os.Getenv("ORCA_NAME"), "name of environment (namespace) to delete. Overrides $ORCA_NAME")
+	f.StringVarP(&e.name, "name", "n", os.Getenv("ORCA_NAME"), "name of environment (namespace) to lock. Overrides $ORCA_NAME")
 	f.StringVar(&e.kubeContext, "kube-context", os.Getenv("ORCA_KUBE_CONTEXT"), "name of the kubeconfig context to use. Overrides $ORCA_KUBE_CONTEXT")
 
 	return cmd
@@ -460,7 +460,7 @@ func NewUnlockEnvCmd(out io.Writer) *cobra.Command {
 
 	f := cmd.Flags()
 
-	f.StringVarP(&e.name, "name", "n", os.Getenv("ORCA_NAME"), "name of environment (namespace) to delete. Overrides $ORCA_NAME")
+	f.StringVarP(&e.name, "name", "n", os.Getenv("ORCA_NAME"), "name of environment (namespace) to unlock. Overrides $ORCA_NAME")
 	f.StringVar(&e.kubeContext, "kube-context", os.Getenv("ORCA_KUBE_CONTEXT"), "name of the kubeconfig context to use. Overrides $ORCA_KUBE_CONTEXT")
 
 	return cmd
@@ -574,7 +574,7 @@ func NewValidateEnvCmd(out io.Writer) *cobra.Command {
 
 	f := cmd.Flags()
 
-	f.StringVarP(&e.name, "name", "n", os.Getenv("ORCA_NAME"), "name of environment (namespace) to delete. Overrides $ORCA_NAME")
+	f.StringVarP(&e.name, "name", "n", os.Getenv("ORCA_NAME"), "name of environment (namespace) to validate. Overrides $ORCA_NAME")
 	f.StringVar(&e.kubeContext, "kube-context", os.Getenv("ORCA_KUBE_CONTEXT"), "name of the kubeconfig context to use. Overrides $ORCA_KUBE_CONTEXT")
 
 	return cmd


### PR DESCRIPTION
The documentation for the `-n` flag in all three of these commands
said "the environment to delete" which isn't accurate.